### PR TITLE
update squid.pp

### DIFF
--- a/manifests/squid.pp
+++ b/manifests/squid.pp
@@ -44,7 +44,7 @@ class frontier::squid (
   $max_access_log = undef,
   $install_resource = false,
   $resource_path = $frontier::params::resource_agents_path
-) inherits params {
+) inherits frontier::params {
   yumrepo {'cern-frontier':
       baseurl => 'http://frontier.cern.ch/dist/rpms/',
       enabled => 1,


### PR DESCRIPTION
the update fix this error
Could not find parent resource type '::params' of type hostclass
