### PR TITLE
facts: rpm query may return nil.

### DIFF
--- a/lib/facter/frontier-squid-majver.rb
+++ b/lib/facter/frontier-squid-majver.rb
@@ -3,8 +3,10 @@ require 'facter'
 
 version = Facter::Util::Resolution.exec("rpm -q frontier-squid --queryformat '[%{NAME} %{VERSION}-%{RELEASE}\n]'")
 
-Facter.add("#{version.split[0]}_majver".gsub('-','_')) do
-    setcode do
-          "#{version.split[1].split('.')[0]}"
+if (version != nil)
+    Facter.add("#{version.split[0]}_majver".gsub('-','_')) do
+        setcode do
+              "#{version.split[1].split('.')[0]}"
+        end
     end
 end

--- a/lib/facter/frontier-squid-version.rb
+++ b/lib/facter/frontier-squid-version.rb
@@ -3,8 +3,10 @@ require 'facter'
 
 version = Facter::Util::Resolution.exec("rpm -q frontier-squid --queryformat '[%{NAME} %{VERSION}-%{RELEASE}\n]'")
 
-Facter.add("#{version.split[0]}".gsub('-','_')) do
-    setcode do
-          "#{version.split[1]}"
+if (version != nil)
+    Facter.add("#{version.split[0]}".gsub('-','_')) do
+        setcode do
+              "#{version.split[1]}"
+        end
     end
 end


### PR DESCRIPTION
Either on Debian OS, or if squid is not installed.
In this case, don't add the fact.

Namely, this fixes:
```
Error: Facter: error while resolving custom facts in /opt/puppetlabs/puppet/cache/lib/facter/frontier-squid-majver.rb: undefined method `split' for nil:NilClass
Error: Facter: error while resolving custom facts in /opt/puppetlabs/puppet/cache/lib/facter/frontier-squid-version.rb: undefined method `split' for nil:NilClass
```
which is otherwise shown on any machine which is not a squid server. 