### PR TITLE
repo: Add missing require on RPM key registration.

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -32,6 +32,7 @@
     priority=> $priority,
     gpgkey => "file:///etc/pki/rpm-gpg/${gpgkey}",
     metadata_expire => $metadata_expire,
+    require => Exec["gpgfile $gpgkey import"],
   }
 
   #If there is a "purge" on the repos dir, make sure we're not purged :


### PR DESCRIPTION
Order may end up incorrect and require two puppet runs.