### PR TITLE
added check to ensure valid version returned for facts before setting fixes #7

### DIFF
--- a/lib/facter/frontier-squid-majver.rb
+++ b/lib/facter/frontier-squid-majver.rb
@@ -3,8 +3,11 @@ require 'facter'
 
 version = Facter::Util::Resolution.exec("rpm -q frontier-squid --queryformat '[%{NAME} %{VERSION}-%{RELEASE}\n]'")
 
-Facter.add("#{version.split[0]}_majver".gsub('-','_')) do
-    setcode do
-          "#{version.split[1].split('.')[0]}"
+if version
+    Facter.add("#{version.split[0]}_majver".gsub('-','_')) do
+        setcode do
+            "#{version.split[1].split('.')[0]}"
+        end
+
     end
 end

--- a/lib/facter/frontier-squid-version.rb
+++ b/lib/facter/frontier-squid-version.rb
@@ -3,8 +3,11 @@ require 'facter'
 
 version = Facter::Util::Resolution.exec("rpm -q frontier-squid --queryformat '[%{NAME} %{VERSION}-%{RELEASE}\n]'")
 
-Facter.add("#{version.split[0]}".gsub('-','_')) do
-    setcode do
-          "#{version.split[1]}"
+if version
+    Facter.add("#{version.split[0]}_majver".gsub('-','_')) do
+        setcode do
+            "#{version.split[1].split('.')[0]}"
+        end
+
     end
 end


### PR DESCRIPTION
Check that version contains a value before attempting to split.